### PR TITLE
small fix to the skipFiles option in postproc.py

### DIFF
--- a/python/postprocessing/wmass/postproc.py
+++ b/python/postprocessing/wmass/postproc.py
@@ -202,6 +202,9 @@ if args.condor:
     skipFiles = getLinesFromFile(args.condorSkipFiles) if args.condorSkipFiles else []
     selectFiles = getLinesFromFile(args.condorSelectFiles) if args.condorSelectFiles else []
 
+    skipFiles   = [i.strip().replace('_Skim','') for i in skipFiles]
+    selectFiles = [i.strip().replace('_Skim','') for i in selectFiles]
+
     ## get the list of files from the given
     listoffiles = []
     for root, dirnames, filenames in os.walk(args.dsdir):


### PR DESCRIPTION
the output files have a "_Skim" added before .root. this is now removed upon checking whether the file should be skipped.