### PR TITLE
Additional condor functionalities

### DIFF
--- a/python/postprocessing/tools.py
+++ b/python/postprocessing/tools.py
@@ -76,3 +76,29 @@ def matchObjectCollectionMultiple(
                 matched.append(c)
         pairs[obj] = matched
     return pairs
+
+def stringToLeafType(string, unknownType = "Float_t", setUnknownToDefault = False):
+    types = {"Float_t"  : "F",
+             "Double_t" : "D",
+             "UInt_t"   : "i",
+             "Int_t"    : "I",
+             "Char_t"   : "B",
+             "UChar_t"  : "b",
+             "Bool_t"   : "O",
+             "ULong64_t": "l",
+             "Long64_t" : "L",
+             "UShort_t" : "s",
+             "Short_t"  : "S"
+             }
+    if string in types:
+        return types[string]
+    else:
+        if setUnknownToDefault:
+            print "Warning in stringToLeafType(): setting unknown input string %s to %s" % (string,unknownType)
+            return types[unknownType]
+        else:
+            print "Error in stringToLeafType(): unknown input string %s. Abort" % string
+            quit()
+    return "F" # just in case, but will bever get here
+
+

--- a/python/postprocessing/wmass/SequenceBuilder.py
+++ b/python/postprocessing/wmass/SequenceBuilder.py
@@ -18,7 +18,7 @@ from PhysicsTools.NanoAODTools.postprocessing.wmass.triggerMatchProducer import 
 from PhysicsTools.NanoAODTools.postprocessing.wmass.jetReCleaner import *
 
 class SequenceBuilder:
-    def __init__(self, isMC, dataYear, runPeriod, jesUncert, eraVFP, passall, genOnly, addOptional):
+    def __init__(self, isMC, dataYear, runPeriod, jesUncert, eraVFP, passall, genOnly, addOptional, onlyTestModules=False):
         self.isMC=isMC
         self.dataYear=dataYear
         self.runPeriod=runPeriod
@@ -27,6 +27,7 @@ class SequenceBuilder:
         self.genOnly = genOnly
         self.eraVFP = eraVFP
         self.addOptional = addOptional
+        self.onlyTestModules = onlyTestModules
         self.modules=[]
             
     #this sequence will always be run
@@ -99,7 +100,19 @@ class SequenceBuilder:
 
         return optionals
 
+    #list of test modules (only these will run if requested)
+    def testSequence(self):
+        optionals=[JetReCleaner(label="Clean", jetCollection="Jet", particleCollection="Muon", deltaRforCleaning=0.4, variables=["pt","eta","phi"])]
+
+        return optionals
+
+
     def buildFinalSequence(self):
+        
+        if self.onlyTestModules:
+            self.modules.extend(self.testSequence())
+            return self.modules
+
         if (not self.genOnly):
             self.modules.extend(self.makeBaselineSequence())
             

--- a/python/postprocessing/wmass/keep_and_drop_Data.txt
+++ b/python/postprocessing/wmass/keep_and_drop_Data.txt
@@ -3,7 +3,6 @@ keep event*
 keep run*
 keep luminosityBlock*
 keep Muon*
-keep event*
 keep MET*
 drop TkMET*
 keep PV*
@@ -17,3 +16,11 @@ keep nPair*
 keep Idx_tag*
 keep Idx_probe*
 keep Is_pass*
+keep Jet_eta
+keep Jet_pt
+keep Jet_phi
+keep Jet_mass
+keep Jet_muEF
+keep Jet_puId
+keep Jet_jetId
+keep Jet_MuonClean*

--- a/python/postprocessing/wmass/keep_and_drop_Data.txt
+++ b/python/postprocessing/wmass/keep_and_drop_Data.txt
@@ -16,6 +16,7 @@ keep nPair*
 keep Idx_tag*
 keep Idx_probe*
 keep Is_pass*
+keep nJet
 keep Jet_eta
 keep Jet_pt
 keep Jet_phi
@@ -23,4 +24,5 @@ keep Jet_mass
 keep Jet_muEF
 keep Jet_puId
 keep Jet_jetId
+keep nJet_MuonClean
 keep Jet_MuonClean*

--- a/python/postprocessing/wmass/keep_and_drop_MC.txt
+++ b/python/postprocessing/wmass/keep_and_drop_MC.txt
@@ -29,6 +29,7 @@ keep scale*
 keep pdf*
 keep mass*
 keep GenVtx_z
+keep nJet
 keep Jet_eta
 keep Jet_pt
 keep Jet_phi
@@ -36,4 +37,5 @@ keep Jet_mass
 keep Jet_muEF
 keep Jet_puId
 keep Jet_jetId
+keep nJet_MuonClean
 keep Jet_MuonClean*

--- a/python/postprocessing/wmass/keep_and_drop_MC.txt
+++ b/python/postprocessing/wmass/keep_and_drop_MC.txt
@@ -13,7 +13,6 @@ keep Muon*
 keep MET*
 keep *nom*
 keep GenMET*
-keep puWeight*
 keep PrefireWeight*
 keep HLT_SingleMu24
 keep HLT_SingleMu27
@@ -29,3 +28,12 @@ keep *preFSR
 keep scale*
 keep pdf*
 keep mass*
+keep GenVtx_z
+keep Jet_eta
+keep Jet_pt
+keep Jet_phi
+keep Jet_mass
+keep Jet_muEF
+keep Jet_puId
+keep Jet_jetId
+keep Jet_MuonClean*

--- a/python/postprocessing/wmass/keep_and_drop_TEST.txt
+++ b/python/postprocessing/wmass/keep_and_drop_TEST.txt
@@ -2,13 +2,9 @@ drop *
 keep event*
 keep run*
 keep puW*
-keep Pileup*
 keep luminosityBlock*
 keep genWeight*
-keep Generator*
-keep GenPart*
-keep LHEWeight*
-keep PV*
 keep Muon*
 keep TrigObj*
+keep nJet*
 keep Jet*

--- a/python/postprocessing/wmass/lheWeightsFlattener.py
+++ b/python/postprocessing/wmass/lheWeightsFlattener.py
@@ -20,9 +20,11 @@ class lheWeightsFlattener(Module):
                 ("1","1"), ("1","2"), ("2", "05"), ("2", "1"), ("2", "2")]:
             self.out.branch("scaleWeightMuR%sMuF%s" % varPair, "F")
 
-        for i in range(self.NumNNPDFWeights):
-            self.out.branch("pdfWeightNNPDF%i" % i, "F")
-        
+        # for i in range(self.NumNNPDFWeights):
+        #    self.out.branch("pdfWeightNNPDF%i" % i, "F")
+        self.out.branch("npdfWeightNNPDF", "i")
+        self.out.branch("pdfWeightNNPDF", "F", lenVar="npdfWeightNNPDF")
+
         for i in range(self.massGrid, self.maxMassShift+self.massGrid, self.massGrid):
             self.out.branch("massShift%iMeVUp" % i, "F")
             self.out.branch("massShift%iMeVDown" % i, "F")
@@ -67,8 +69,12 @@ class lheWeightsFlattener(Module):
         if len(self.LHEPdfWeight) < self.NumNNPDFWeights:
             raise RuntimeError("Found poorly formed LHE Scale weights")
 
+        pdfWeights = []
         for i in range(self.NumNNPDFWeights):
-            self.out.fillBranch("pdfWeightNNPDF%i" % i, self.LHEPdfWeight[i])
+        #     self.out.fillBranch("pdfWeightNNPDF%i" % i, self.LHEPdfWeight[i])
+            pdfWeights.append(self.LHEPdfWeight[i])
+        self.out.fillBranch("npdfWeightNNPDF", self.NumNNPDFWeights)
+        self.out.fillBranch("pdfWeightNNPDF" , pdfWeights)
 
         return True
 

--- a/python/postprocessing/wmass/postproc.py
+++ b/python/postprocessing/wmass/postproc.py
@@ -206,7 +206,9 @@ else:
 bob=SequenceBuilder(isMC, dataYear, runPeriod, jesUncert, eraVFP, passall, genOnly, addOptional=True, onlyTestModules=isTest)
 modules=bob.buildFinalSequence()
 
-treecut = ("Entry$<" + str(maxEvents) if maxEvents > 0 else None)
+# better to use the maxEntries argument of PostProcessor (so that one can use it inside that class)
+#treecut = ("Entry$<" + str(maxEvents) if maxEvents > 0 else None)
+treecut = None
 kd_file = "keep_and_drop"
 if isMC:
     kd_file += "_MC"
@@ -310,14 +312,16 @@ Error      = {cd}/log_condor_{dm}{rp}_chunk{ch}.error\n'''.format(cd=args.condor
 
 else:
     p = PostProcessor(outputDir=outDir,  
-                  inputFiles=(input_files if crab==0 else inputFiles()),
-                  cut=treecut,      
-                  modules=modules,
-                  provenance=True,
-                  outputbranchsel=kd_file,
-                  fwkJobReport=(False if crab==0 else True),
-                  jsonInput=(None if crab==0 else runsAndLumis()),
-                  compression="LZMA:9"
+                      inputFiles=(input_files if crab==0 else inputFiles()),
+                      cut=treecut,      
+                      modules=modules,
+                      provenance=True,
+                      outputbranchsel=kd_file,
+                      maxEntries=maxEvents if maxEvents>0 else None,
+                      fwkJobReport=(False if crab==0 else True),
+                      jsonInput=(None if crab==0 else runsAndLumis()),
+                      compression="LZMA:9",
+                      saveHistoGenWeights=(True if isMC else False)
                   )
     p.run()
 

--- a/python/postprocessing/wmass/postproc.py
+++ b/python/postprocessing/wmass/postproc.py
@@ -203,7 +203,7 @@ else:
     else : 
         input_files.extend( inputFile.split(',') )
 
-bob=SequenceBuilder(isMC, dataYear, runPeriod, jesUncert, eraVFP, passall, genOnly, isTest)
+bob=SequenceBuilder(isMC, dataYear, runPeriod, jesUncert, eraVFP, passall, genOnly, addOptional=True)
 modules=bob.buildFinalSequence()
 
 treecut = ("Entry$<" + str(maxEvents) if maxEvents > 0 else None)

--- a/python/postprocessing/wmass/postproc.py
+++ b/python/postprocessing/wmass/postproc.py
@@ -79,7 +79,7 @@ parser.add_argument('-runPeriod', '--runPeriod',type=str, default="",    help=""
 parser.add_argument('-genOnly',   '--genOnly',  type=int, default=0,      help="")
 parser.add_argument('-trigOnly',  '--trigOnly', type=int, default=0,      help="")
 parser.add_argument('-iFile',     '--iFile',    type=str, default="",     help="")
-parser.add_argument(              '--isTest',   action='store_true',      help="run test modules, hardcoded inside")
+parser.add_argument(              '--isTest',   action='store_true',      help="run test modules, hardcoded inside SequenceBuilder.py (will use keep_and_drop_TEST.txt)")
 parser.add_argument('--customKeepDrop',         type=str, default="",     help="use this file for keep-drop")
 parser.add_argument('-o',         '--outDir',   type=str, default=".",    help="output directory")
 parser.add_argument('-eraVFP',    '--eraVFP',   type=str, default="",     help="Specify one key in ['preVFP','postVFP'] to run on UL2016 MC samples. Only works with --isMC and --dataYear 2016")
@@ -203,7 +203,7 @@ else:
     else : 
         input_files.extend( inputFile.split(',') )
 
-bob=SequenceBuilder(isMC, dataYear, runPeriod, jesUncert, eraVFP, passall, genOnly, addOptional=True)
+bob=SequenceBuilder(isMC, dataYear, runPeriod, jesUncert, eraVFP, passall, genOnly, addOptional=True, onlyTestModules=isTest)
 modules=bob.buildFinalSequence()
 
 treecut = ("Entry$<" + str(maxEvents) if maxEvents > 0 else None)

--- a/python/postprocessing/wmass/postproc.py
+++ b/python/postprocessing/wmass/postproc.py
@@ -15,16 +15,18 @@ echo '===setting outdir'
 OUTDIR=$1
 echo '===changing into proper directory'
 cd {pwd}
-echo '===performing cmsenv'
+echo '===doing cmsenv'
 eval $(scramv1 runtime -sh);
 echo '===moving back to the node'
 cd -
 echo '===copying keppdropfiles'
 cp {pwd}/keep_and_drop*.txt .
 shift
+echo '===this is pwd at the moment'
+pwd
 echo '===now running command'
-echo python $@
-python $@
+echo python $@ -o $PWD
+python $@ -o $PWD
 echo '====doing ls in current dir'
 ls
 echo '===now compressing the files into subdir'
@@ -35,6 +37,12 @@ do
 done
 echo '===now copying the files to eos!'
 eos cp compressed/*.root $OUTDIR/
+echo '===cleaning up'
+rm *.root
+rm compressed/*.*
+rmdir compressed
+rm keep_and_drop*.txt
+echo '===done cleaning'
 echo '===done'
 '''.format(pwd=os.environ['PWD']))
     f.close()

--- a/python/postprocessing/wmass/postproc.py
+++ b/python/postprocessing/wmass/postproc.py
@@ -9,6 +9,11 @@ from importlib import import_module
 from PhysicsTools.NanoAODTools.postprocessing.framework.postprocessor import PostProcessor
 from PhysicsTools.NanoAODTools.postprocessing.wmass.SequenceBuilder import SequenceBuilder
 
+# example
+# python postproc.py -o /eos/cms/store/cmst3/group/wmass/w-mass-13TeV/postNANO/dec2020/DYJetsToMuMu_postVFP/ -d /eos/cms/store/cmst3/group/wmass/sroychow/nanov8/DYJetsToMuMu_M-50_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/RunIISummer20UL16MiniAOD-106X_mcRun2_asymptotic_v13-v2/  --passall 1 --eraVFP postVFP --isMC 1
+# condor options
+# -condor --condorDir postprocDY_postVFP -t 86400 -j ZmumuPostVFP -n 2
+
 def makeDummyFile():
     f = open('dummy_exec.sh', 'w')
     f.write('''#!/bin/bash
@@ -81,6 +86,7 @@ parser.add_argument('-eraVFP',    '--eraVFP',   type=str, default="",     help="
 parser.add_argument('-condor'   , '--condor',  action='store_true',     help="run on condor instead of locally or on crab")
 parser.add_argument('-d'         , '--dsdir'    , type=str , default="", help="input directory of dataset, to be given with condor option!")
 parser.add_argument('-n'         , '--nfiles'   , type=int , default=5 , help="number of files to run per condor job")
+parser.add_argument('-j'         , '--jobname'  , type=str , default="" , help="Assign name to condor job, for easier tracking (by default the cluster ID is by condor_q)")
 parser.add_argument('-t'         , '--runtime'  , type=int , default=43200 , help="MaxRunTime for condor jobs, in seconds")
 parser.add_argument('-condorDir' , '--condorDir', type=str , default="", help="Mandatory to run with condor, specify output folder to save condor files, logs, etc...")
 parser.add_argument('-condorSkipFiles' , '--condorSkipFiles', type=str , default="", help="When using condor, can specify a file containing a list of files to be skipped (useful for resubmitting failed jobs)")
@@ -105,6 +111,12 @@ outDir = args.outDir
 eraVFP = args.eraVFP
 
 isData = not isMC
+
+if outDir not in [".", "./"]:
+    print "Creating output directory"
+    cmd = "mkdir -p {d}".format(d=outDir)
+    print cmd
+    os.system(cmd)
 
 print "isMC =", bcolors.OKBLUE, isMC, bcolors.ENDC, \
     "genOnly =", bcolors.OKBLUE, genOnly, bcolors.ENDC, \
@@ -272,6 +284,8 @@ transfer_output_files = ""
 request_memory = 2000
 transfer_output_files = ""
 +MaxRuntime = {t}\n'''.format(here=os.environ['PWD'],t=args.runtime)
+    if args.jobname:
+        job_desc += '+JobBatchName = "%s"\n' % args.jobname
     # some customization
     if os.environ['USER'] in ['mdunser', 'kelong', 'bendavid']:
         job_desc += '+AccountingGroup = "group_u_CMST3.all"\n'

--- a/python/postprocessing/wmass/skimmer.py
+++ b/python/postprocessing/wmass/skimmer.py
@@ -1,0 +1,47 @@
+import ROOT
+import math
+ROOT.PyConfig.IgnoreCommandLineOptions = True
+
+from PhysicsTools.NanoAODTools.postprocessing.framework.datamodel import Collection 
+from PhysicsTools.NanoAODTools.postprocessing.framework.eventloop import Module
+
+def muonPassSelection(mu, skipIsolation=False):
+    # this might be looser than the actual analysis selection, to be more flexible
+    if mu.pt > 24 and mu.mediumId == 1 and (skipIsolation or mu.pfRelIso04_all < 0.15) and abs(mu.dxy) < 0.05 and abs(mu.dz) < 0.2:
+        return True
+    else:
+        return False
+
+class skimmer(Module):
+    def __init__(self, isWlike=False):
+        self.isWlike = isWlike
+    def beginJob(self):
+        pass
+    def endJob(self):
+        pass
+    def beginFile(self, inputFile, outputFile, inputTree, wrappedOutputTree):
+        pass
+    def endFile(self, inputFile, outputFile, inputTree, wrappedOutputTree):
+        pass
+    def analyze(self, event):
+        """process event, return True (go to next module) or False (fail, go to next event)"""
+
+        # Muon selection
+        all_muons = Collection(event, "Muon")
+        nMuons = len(all_muons)
+        pass_muons = [mu for mu in all_muons if muonPassSelection(mu, skipIsolation=True)]
+        if self.isWlike:
+            if nMuons < 2: return False
+            # require that at least two muons pass the selection except isolation
+            if len(pass_muons) < 2: return False
+        else:
+            if nMuons < 1: return False
+            # require that at least one muon passes the selection except isolation
+            if len(pass_muons) < 1: return False
+
+        return True
+
+# define modules using the syntax 'name = lambda : constructor' to avoid having them loaded when not needed
+
+skimmerWmassModule = lambda : skimmer(isWlike=False) 
+skimmerWlikeModule = lambda : skimmer(isWlike=True) 

--- a/scripts/checkZombies.py
+++ b/scripts/checkZombies.py
@@ -13,7 +13,7 @@ nTot = len(allfiles)
 
 for i,f in enumerate(allfiles):
     
-    rf = ROOT.TFile(os.path.join(d,f),'read')
+    rf = ROOT.TFile.Open(os.path.join(d,f),'read')
     if rf.IsZombie() or rf.TestBit(ROOT.TFile.kRecovered) or rf.GetListOfKeys().GetSize()==0:
         faultyfiles.append(d+f)
     if rf.IsOpen():

--- a/scripts/checkZombies.py
+++ b/scripts/checkZombies.py
@@ -9,15 +9,19 @@ allfiles = [i for i in os.listdir(d) if '.root' in i]
 print('checking', len(allfiles), 'files')
 
 faultyfiles = []
+nTot = len(allfiles)
 
-for f in allfiles:
+for i,f in enumerate(allfiles):
     
     rf = ROOT.TFile(os.path.join(d,f),'read')
-    if rf.IsZombie():
+    if rf.IsZombie() or rf.TestBit(ROOT.TFile.kRecovered) or rf.GetListOfKeys().GetSize()==0:
         faultyfiles.append(d+f)
+    if rf.IsOpen():
+        rf.Close()
+    sys.stdout.write('>>> File {num}/{tot}   \r'.format(num=i+1,tot=nTot))
+    sys.stdout.flush()
 
-    rf.Close()
-
+print "\n"
 print('faulty files:')
 print('================')
 for i in faultyfiles:

--- a/scripts/checkZombies.py
+++ b/scripts/checkZombies.py
@@ -1,0 +1,26 @@
+import ROOT, sys, os
+
+args = sys.argv
+d = sys.argv[1]
+
+
+allfiles = [i for i in os.listdir(d) if '.root' in i]
+
+print('checking', len(allfiles), 'files')
+
+faultyfiles = []
+
+for f in allfiles:
+    
+    rf = ROOT.TFile(os.path.join(d,f),'read')
+    if rf.IsZombie():
+        faultyfiles.append(d+f)
+
+    rf.Close()
+
+print('faulty files:')
+print('================')
+for i in faultyfiles:
+    print i
+
+print('found', len(faultyfiles), 'faulty files')


### PR DESCRIPTION
More options: customise runtime and jobname (latter is useful for monitoring with condor_q).

Shuffle list of input files when using condor (to ensure more uniform runtime when input files can have very different size)

Adding comment with example command for reference

Also updating keep drop files with missing variables. These are
- gen vertex Z for vertex study
- some jet variables for fake rate measurements (might need at least pt/eta/phi/mass/puID/jetID/muEF)
- Jet_MuonClean collection (currently the jet cleaner module is not enabled by default in the sequence, in addition for now it only stores the idx of the corresponding jet in Jet collection, while perhaps it might be worth to have direct access to the few attribute specified in the previous bullet)

There are also some other variables either in the MC or Data file which could probably be dropped (for now I kept them, except for some duplicates). 